### PR TITLE
Public export of MatchtigEdgeData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "genome-graph"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927bf3c9401db87a655d6cfef89f6eba053fb9bf1e912d25a5c84f7261f6d04c"
+checksum = "d768428a2a8e8ee32ff36b2c0872adab5822a05e57119e33cace7f695d2cea32"
 dependencies = [
  "anyhow",
  "bigraph",
@@ -610,9 +610,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.136"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libm"
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "matchtigs"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "atomic-counter",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchtigs"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Sebastian Schmidt <sebastian.schmidt@helsinki.fi>"]
 description = "Different algorithms for computing small and minimum plain text representations of kmer sets."
 keywords = ["compression", "plain-text", "kmer", "genome", "bio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchtigs"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Sebastian Schmidt <sebastian.schmidt@helsinki.fi>"]
 description = "Different algorithms for computing small and minimum plain text representations of kmer sets."
 keywords = ["compression", "plain-text", "kmer", "genome", "bio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchtigs"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["Sebastian Schmidt <sebastian.schmidt@helsinki.fi>"]
 description = "Different algorithms for computing small and minimum plain text representations of kmer sets."
 keywords = ["compression", "plain-text", "kmer", "genome", "bio"]
@@ -15,7 +15,7 @@ license-file = "LICENSE.txt"
 
 [lib]
 name = "libmatchtigs"
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 path = "src/lib.rs"
 
 [[bin]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,5 @@ pub use implementation::{
     greedytigs::GreedytigAlgorithm, greedytigs::GreedytigAlgorithmConfiguration,
     matchtigs::MatchtigAlgorithm, matchtigs::MatchtigAlgorithmConfiguration,
     pathtigs::PathtigAlgorithm, write_duplication_bitvector, write_duplication_bitvector_to_file,
-    HeapType, NodeWeightArrayType, TigAlgorithm,
+    HeapType, MatchtigEdgeData, NodeWeightArrayType, TigAlgorithm,
 };


### PR DESCRIPTION
Add public export of MatchtigEdgeData to allow trait definition outside the crate